### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MyAIServ: AI-Powered FastAPI Server with MCP 🚀
 
+[![smithery badge](https://smithery.ai/badge/@eagurin/myaiserv)](https://smithery.ai/server/@eagurin/myaiserv)
+
 High-performance FastAPI server implementing Model Context Protocol (MCP) for seamless integration with Large Language Models (LLMs). Built with modern stack: FastAPI, Elasticsearch, Redis, Prometheus, and Grafana.
 
 [View Detailed Architecture](ARCHITECTURE.md)
@@ -15,6 +17,15 @@ High-performance FastAPI server implementing Model Context Protocol (MCP) for se
 
 ## Quick Start 🚀
 
+### Installing via Smithery
+
+To install AI-Powered FastAPI Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@eagurin/myaiserv):
+
+```bash
+npx -y @smithery/cli install @eagurin/myaiserv --client claude
+```
+
+### Manual Installation
 ```bash
 # Clone and setup
 git clone https://github.com/eagurin/myaiserv.git

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required: []
+    properties:
+      exampleEnvVariable:
+        type: string
+        description: An example environment variable extracted from the .env.example
+          file. Replace with actual variables as needed.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'uvicorn', args: ['app.main:app', '--reload'], env: { EXAMPLE_ENV_VAR: config.exampleEnvVariable } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@eagurin/myaiserv?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂